### PR TITLE
Add onRemoved to StatusUpdateListener

### DIFF
--- a/status-core/src/main/java/com/indeed/status/core/AbstractDependencyManager.java
+++ b/status-core/src/main/java/com/indeed/status/core/AbstractDependencyManager.java
@@ -341,7 +341,13 @@ abstract public class AbstractDependencyManager implements StatusUpdateProducer,
             pinger.cancel(true);
         }
 
-        return dependencies.remove(id);
+        final Dependency removedDependency = dependencies.remove(id);
+
+        if (removedDependency != null) {
+            updateHandler.onRemoved(removedDependency);
+        }
+
+        return removedDependency;
     }
 
     public Collection<Dependency> getDependencies() {
@@ -361,6 +367,11 @@ abstract public class AbstractDependencyManager implements StatusUpdateProducer,
     @Override
     public void onChecked(@Nonnull final Dependency source, @Nonnull final CheckResult result) {
         updateHandler.onChecked(source, result);
+    }
+
+    @Override
+    public void onRemoved(@Nonnull final Dependency dependency) {
+        updateHandler.onRemoved(dependency);
     }
 
     @Override

--- a/status-core/src/main/java/com/indeed/status/core/StatusUpdateDelegate.java
+++ b/status-core/src/main/java/com/indeed/status/core/StatusUpdateDelegate.java
@@ -75,6 +75,20 @@ class StatusUpdateDelegate implements StatusUpdateProducer, StatusUpdateListener
     }
 
     @Override
+    public void onRemoved(@Nonnull final Dependency dependency) {
+        for (final StatusUpdateListener listener: listeners) {
+            try {
+                listener.onRemoved(dependency);
+
+            } catch(RuntimeException e) {
+                log.error("Status update listeners should not throw errors. Something must be tragically wrong.", e);
+
+                // Swallow runtime exceptions. Allow Errors through.
+            }
+        }
+    }
+
+    @Override
     public void addListener (final StatusUpdateListener listener) {
         listeners.add(listener);
     }

--- a/status-core/src/main/java/com/indeed/status/core/StatusUpdateListener.java
+++ b/status-core/src/main/java/com/indeed/status/core/StatusUpdateListener.java
@@ -46,4 +46,11 @@ public interface StatusUpdateListener {
      * @param dependency The dependency being added.
      */
     void onAdded(@Nonnull final Dependency dependency);
+
+    /**
+     * Triggered when a dependency is removed
+     *
+     * @param dependency The dependency being removed.
+     */
+    default void onRemoved(@Nonnull final Dependency dependency) {}
 }


### PR DESCRIPTION
Allow listening for when dependencies are removed.

eg: This would allow a Background `DependencyManager` to remove dependencies when removed from the Live `DependencyManager`.
