### PR TITLE
Fix #25: upgrade `jackson-databind` dependency from 2.9.10/2.7.9 to 2.10.5.1

### DIFF
--- a/status-core/build.gradle
+++ b/status-core/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     compile library('log4j:log4j')
     compile 'com.indeed:util-core:1.0.19'
     compile 'com.indeed:util-varexport:1.0.19'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.9.10'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.10.5.1'
     compile library('com.google.guava:guava')
 
     compileOnly library('com.google.code.findbugs:jsr305')

--- a/status-web/build.gradle
+++ b/status-web/build.gradle
@@ -7,7 +7,7 @@ ext['indeed.publish.name'] = 'status-web'
 dependencies {
     compile project(':status-core')
     compile 'com.indeed:util-core:1.0.19'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.7.9'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.10.5.1'
     compile library('com.google.guava:guava')
     compile library('log4j:log4j')
 


### PR DESCRIPTION
To resolve CVE warnings by Snyk: 2.10.5.1 contains all the latest fixes.
(also noticed that `status-web` had even older version, not updated with previous upgrade)