### PR TITLE
Make DEFAULT_DOCUMENTATION_URL public

### DIFF
--- a/status-core/src/main/java/com/indeed/status/core/AbstractDependency.java
+++ b/status-core/src/main/java/com/indeed/status/core/AbstractDependency.java
@@ -25,7 +25,7 @@ public abstract class AbstractDependency implements Dependency {
     public static final long DEFAULT_PING_PERIOD = 30 * 1000; // 30 seconds
     public static final DependencyType DEFAULT_TYPE = DependencyType.StandardDependencyTypes.OTHER;
     public static final String DEFAULT_SERVICE_POOL = "not specified";
-    protected static final String DEFAULT_DOCUMENTATION_URL =
+    public static final String DEFAULT_DOCUMENTATION_URL =
             "http://www.example.com/<dependency-id>";
 
     /**


### PR DESCRIPTION
Make AbstractDependency.DEFAULT_DOCUMENTATION_URL public to facilitate writing code relying on whether a doc url was set or not. With the current visibility of `protected` such code has to either make a dummy class extending `AbstractDependency` or make an instance of a dependency and rely on the url being set to this constant.